### PR TITLE
Update npm publish workflow runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,11 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run test


### PR DESCRIPTION
## Summary
- update publish workflow from Node 18 to Node 22 so latest Vitest can run in release publishing
- update checkout/setup-node actions to v4

## Verification
- npm test
- npm run build