### PR TITLE
Remove release publish version mutation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ jobs:
       - run: npm install
       - run: npm run test
       - run: npm run build
-      - run: npm version ${{ github.event.release.tag_name }} --no-git-tag-version
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- remove npm version mutation from release workflow
- package.json now carries the release version before the GitHub release is created

## Verification
- npm test
- npm run build