### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@ name: Publish Package to npmjs
 on:
   release:
     types: [created]
+permissions:
+  contents: read
+  id-token: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +17,4 @@ jobs:
       - run: npm install
       - run: npm run test
       - run: npm run build
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance


### PR DESCRIPTION
## Summary
- switch release workflow from token-based npm publish to Trusted Publishing/OIDC
- grant id-token permission and publish with provenance

## Verification
- npm test
- npm run build