### PR TITLE
Use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run test


### PR DESCRIPTION
## Summary
- run the npm publish workflow on Node 24 so npm uses the current Trusted Publishing/OIDC flow

## Validation
- previous release run passed install, tests, and build before failing in npm publish auth